### PR TITLE
Remote udp (for windows etc)

### DIFF
--- a/vice/src/c64/cart/Makefile.am
+++ b/vice/src/c64/cart/Makefile.am
@@ -246,5 +246,7 @@ libc64commoncart_a_SOURCES = \
 	idunio.h \
 	idunmm.c \
 	idunmm.h \
+	idunsocket.c \
+	idunsocket.h \
 	iduncore.c \
 	iduncore.h

--- a/vice/src/c64/cart/iduncore.c
+++ b/vice/src/c64/cart/iduncore.c
@@ -57,7 +57,11 @@
 #define CMD_UPDATE_PAGE 0xfd
 #define CMD_FREEMAP 0xf7
 
-#define NMIPORT "unix:/tmp/idunmm-nmi"
+// For nmi local unix domain datagram socket
+#define NMI_UNIX_DOMAIN_PATH "/tmp/idunmm-nmi"
+// For nmi udp socket
+#define NMI_UDP_PORT 64128
+
 // We use vice alarms to poll for nmi messages
 #define NMIMSG_POLL_INTERVAL 128    //128 microsecs
 
@@ -65,23 +69,26 @@
 static uint8_t recvBuf[MAX_PIPE_MSG_BYTES];
 static uint8_t blockMem[16384];
 static uint8_t boot_rom_bkup[496];
-static io_iduncart_t iduncart = {NULL, NULL, NULL, NULL, NULL, NULL, 0, SYSTEM_BLOCK, 0, 0, blockMem};
+static io_iduncart_t iduncart = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, SYSTEM_BLOCK, 0, 0, blockMem};
 static unsigned int nmi_int_num = 0;
 
-static void nmimsg_alarm_handler(CLOCK offset, void *data);
-struct alarm_s *nmimsg_alarm;
+static void nmimsg_alarm_handler(void *data);
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+static void nmimsg_alarm_handler_unix_domain(CLOCK offset, void *data);
+#endif
+static void nmimsg_alarm_handler_udp(CLOCK offset, void *data);
+struct alarm_s *nmimsg_alarm_unix_domain = NULL;
+struct alarm_s *nmimsg_alarm_udp = NULL;
 
 /* ---------------------------------------------------------------------------------------------------- */
-void nmimsg_alarm_handler(CLOCK offset, void *data)
+void nmimsg_alarm_handler(void *data)
 {
-    alarm_unset(nmimsg_alarm);
-
     if (data) {
-        vice_network_socket_t *s = (vice_network_socket_t *)data;
-        if (vice_network_select_poll_one(s)) {
+        idun_socket_t *s = (idun_socket_t *)data;
+        if (idun_socket_poll(s)) {
             uint8_t buffer[496];
 
-            int numBytes = vice_network_recvfrom(s, buffer, 2, 0);
+            int numBytes = idun_socket_recvfrom(s, buffer, 2, 0);
             if (numBytes != 2) {
                 log_error(LOG_DEFAULT, "NMI request sync.");
                 return;
@@ -99,7 +106,7 @@ void nmimsg_alarm_handler(CLOCK offset, void *data)
             int msgBytes = (buffer[0] ? 256:0) + buffer[1];
             assert(msgBytes <= sizeof buffer);
             
-            numBytes = vice_network_recvfrom(s, buffer, msgBytes, 0);
+            numBytes = idun_socket_recvfrom(s, buffer, msgBytes, 0);
             if (numBytes != msgBytes) {
                 log_error(LOG_DEFAULT, "NMI request size.");
             }
@@ -113,8 +120,24 @@ void nmimsg_alarm_handler(CLOCK offset, void *data)
             }
         }
     }
+}
 
-    alarm_set(nmimsg_alarm, maincpu_clk + NMIMSG_POLL_INTERVAL);
+/* ---------------------------------------------------------------------------------------------------- */
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+void nmimsg_alarm_handler_unix_domain(CLOCK offset, void *data)
+{
+    alarm_unset(nmimsg_alarm_unix_domain);
+    nmimsg_alarm_handler(data);
+    alarm_set(nmimsg_alarm_unix_domain, maincpu_clk + NMIMSG_POLL_INTERVAL);
+}
+#endif
+
+/* ---------------------------------------------------------------------------------------------------- */
+void nmimsg_alarm_handler_udp(CLOCK offset, void *data)
+{
+    alarm_unset(nmimsg_alarm_udp);
+    nmimsg_alarm_handler(data);
+    alarm_set(nmimsg_alarm_udp, maincpu_clk + NMIMSG_POLL_INTERVAL);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */
@@ -264,22 +287,54 @@ io_iduncart_t *iduncart_init(const char *host)
         vice_network_address_close(ad);
     }
 
-    /* setup unix datagram socket for nmi messages */
-    ad = vice_network_address_generate(NMIPORT, 0);
-    if (!ad) {
-        log_error(LOG_DEFAULT, "Fail generate nmi socket '%s'.", NMIPORT);
-    }
-    else {
-        iduncart.nmisock = vice_network_unix(ad);
-        if (!iduncart.nmisock) {
-            log_error(LOG_DEFAULT, "Can't open domain socket for nmi.");
+    /* determine if idunhost is local (127.0.0.1 or localhost) */
+    do {
+        const char *colon = strchr(host, ':');
+        size_t hostlen = colon ? (size_t)(colon - host) : strlen(host);
+        if (!((hostlen == 9 && strncmp(host, "127.0.0.1", 9) == 0) ||
+              (hostlen == 9 && strncmp(host, "localhost", 9) == 0))) {
+            break; /* remote host — skip to UDP below */
         }
-    }
 
-    /* alarm used to poll for nmi messages */
-    nmimsg_alarm = alarm_new(maincpu_alarm_context, "NmiMessageAlarm",
-                            nmimsg_alarm_handler, iduncart.nmisock);
-    alarm_set(nmimsg_alarm, maincpu_clk + NMIMSG_POLL_INTERVAL);
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+        /* setup unix datagram socket for nmi messages - will work only when running vice on the same pi as idun */
+        iduncart.nmisock_unix_domain = idun_socket_open_unix(NMI_UNIX_DOMAIN_PATH);
+        if (!iduncart.nmisock_unix_domain) {
+            log_error(LOG_DEFAULT, "Can't open unix domain socket for nmi.");
+            break;
+        }
+
+        /* alarm used to poll unix domain socket for nmi messages */
+        nmimsg_alarm_unix_domain = alarm_new(maincpu_alarm_context, "NmiMessageAlarmUnixDomain",
+                                             nmimsg_alarm_handler_unix_domain, iduncart.nmisock_unix_domain);
+        alarm_set(nmimsg_alarm_unix_domain, maincpu_clk + NMIMSG_POLL_INTERVAL);
+
+        log_message(LOG_DEFAULT, "Idun unix domain socket bound");
+#else
+        log_error(LOG_DEFAULT, "Unix domain sockets not available; cannot open NMI socket for localhost.");
+#endif
+        return &iduncart;
+    } while(0);
+
+    /* UDP for NMI messages (remote host) */
+    do {
+        if (iduncart.nmisock_unix_domain) {
+            log_message(LOG_DEFAULT, "Not opening idun udp - unix domain socket open for local iduncart");
+        }
+
+        iduncart.nmisock_udp = idun_socket_open_udp(NMI_UDP_PORT);
+        if (!iduncart.nmisock_udp) {
+            log_error(LOG_DEFAULT, "Can't open udp socket for nmi.");
+            break;
+        }
+
+        /* alarm used to poll udp socket for nmi messages */
+        nmimsg_alarm_udp = alarm_new(maincpu_alarm_context, "NmiMessageAlarmUdp",
+                                     nmimsg_alarm_handler_udp, iduncart.nmisock_udp);
+        alarm_set(nmimsg_alarm_udp, maincpu_clk + NMIMSG_POLL_INTERVAL);
+
+        log_message(LOG_DEFAULT, "Idun udp socket bound");
+    } while(0);
 
     return &iduncart;
 }
@@ -287,23 +342,31 @@ io_iduncart_t *iduncart_init(const char *host)
 void iduncart_io_destroy(io_iduncart_t *context)
 {
     log_message(LOG_DEFAULT, "Idun disconnect");
-    alarm_destroy(nmimsg_alarm);
+
+    if (nmimsg_alarm_unix_domain) alarm_destroy(nmimsg_alarm_unix_domain);
+    if (nmimsg_alarm_udp) alarm_destroy(nmimsg_alarm_udp);
+
     if (!context) return;
     
     do {
         if (!context->socket) {
             log_error(LOG_DEFAULT, "Attempt to close non-open idunio");
             break;
-        }    
+        }
         vice_network_socket_close(context->socket);
         context->socket = NULL;
-        if (!context->nmisock) {
-            log_error(LOG_DEFAULT, "Attempt to close non-open idunnmi");
-            break;
-        }    
-        vice_network_socket_close(context->nmisock);
-        context->nmisock = NULL;
     } while (0);
+
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+    if (context->nmisock_unix_domain) {
+        idun_socket_close(context->nmisock_unix_domain);
+        context->nmisock_unix_domain = NULL;
+    }
+#endif
+    if (context->nmisock_udp) {
+        idun_socket_close(context->nmisock_udp);
+        context->nmisock_udp = NULL;
+    }
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/vice/src/c64/cart/iduncore.h
+++ b/vice/src/c64/cart/iduncore.h
@@ -31,10 +31,12 @@
 #include "snapshot.h"
 #include "types.h"
 #include "vicesocket.h"
+#include "idunsocket.h"
 
 typedef struct io_iduncart_s {
     const char *host;
-    vice_network_socket_t *socket, *nmisock;
+    vice_network_socket_t *socket;
+    idun_socket_t *nmisock_unix_domain, *nmisock_udp;
     uint8_t *rombase;
     uint8_t *pfirst, *plast;
     uint8_t m_page, m_block;

--- a/vice/src/c64/cart/idunsocket.c
+++ b/vice/src/c64/cart/idunsocket.c
@@ -1,0 +1,255 @@
+/*
+ * idunsocket.c - Idun cartridge socket abstraction for unix domain and UDP.
+ *
+ * Written by
+ *  Brian Holdsworth <brian.holdsworth@gmail.com>
+ *  Deniss Vorona <dwwretro@gmail.com>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#include "vice.h"
+
+#ifdef HAVE_NETWORK
+
+#include <errno.h>
+#include <string.h>
+
+#include "socketdrv/socketimpl.h"
+
+#ifdef WINDOWS_COMPILE
+# undef INVALID_SOCKET
+# define INVALID_SOCKET -1
+#endif
+
+#include "archdep.h"
+#include "lib.h"
+#include "log.h"
+#include "signals.h"
+#include "idunsocket.h"
+
+/* ---- Idun socket types ---- */
+
+union idun_socket_addresses_u {
+    struct sockaddr generic;
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+    struct sockaddr_un local;
+#endif
+    struct sockaddr_in ipv4;
+};
+
+/*! \internal \brief Simplified variant of vice_network_socket_s for idun datagram usage */
+struct idun_socket_s {
+    SOCKET sockfd;
+};
+
+/* ---- Open functions ---- */
+
+/*! \internal \brief Generate a unix domain socket address
+
+  Initialises a socket address with a unix domain socket address
+
+  \param path
+     Path of a special file which represents the Unix domain socket.
+
+  \return
+     NULL on error;
+     else, a pointer to idun_socket_t on success.
+
+  \remark
+     On platforms which do not support unix domain sockets, this function
+     returns NULL as error.
+*/
+idun_socket_t *idun_socket_open_unix(const char *path)
+{
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+    union idun_socket_addresses_u addr;
+    int sockfd;
+    int err;
+
+    if (path == NULL || path[0] == 0 || strlen(path) >= sizeof(addr.local.sun_path)) {
+        log_error(LOG_DEFAULT,
+                  "Unix domain socket path invalid or too long: '%s'",
+                  path ? path : "(null)");
+        return NULL;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.local.sun_family = AF_UNIX;
+    strcpy(addr.local.sun_path, path);
+
+    sockfd = (int)socket(PF_UNIX, SOCK_DGRAM, 0);
+    if (sockfd == INVALID_SOCKET) {
+        err = errno;
+        log_error(LOG_DEFAULT,
+                  "idun_socket_open_unix(): socket() failed: %s", strerror(err));
+        return NULL;
+    }
+
+    archdep_remove(path);
+
+    if (bind(sockfd, &addr.generic, sizeof(addr.local)) < 0) {
+        err = errno;
+        log_error(LOG_DEFAULT,
+                  "idun_socket_open_unix(): bind() failed: %s", strerror(err));
+        closesocket(sockfd);
+        return NULL;
+    }
+
+    {
+        idun_socket_t *sock = lib_calloc(1, sizeof(*sock));
+        sock->sockfd = sockfd;
+        return sock;
+    }
+#else
+    log_message(LOG_DEFAULT,
+                "Unix domain sockets are not supported in this installation of VICE!\n");
+    return NULL;
+#endif
+}
+
+/*! \brief Open a UDP socket bound to a local port for NMI datagram reception.
+
+  Creates and binds a UDP (SOCK_DGRAM) socket to INADDR_ANY on the given port.
+  Used as the NMI socket on platforms that lack Unix domain socket support
+  (e.g. Windows), where the Idun cartridge host sends interrupt messages as
+  UDP datagrams.  The socket is polled periodically via the VICE alarm system
+  (see iduncore.c).
+
+  \param port
+     The local UDP port number to bind (host byte order). 
+
+  \return
+     Pointer to a newly allocated idun_socket_t on success, or NULL if
+     socket() or bind() fails (error is logged via log_error).
+*/
+idun_socket_t *idun_socket_open_udp(unsigned short port)
+{
+    struct sockaddr_in addr;
+    int sockfd;
+    int err;
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = INADDR_ANY;
+
+    sockfd = (int)socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sockfd == INVALID_SOCKET) {
+        err = errno;
+        log_error(LOG_DEFAULT,
+                  "idun_socket_open_udp(): socket() failed: %s", strerror(err));
+        return NULL;
+    }
+
+    if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        err = errno;
+        log_error(LOG_DEFAULT,
+                  "idun_socket_open_udp(): bind() failed: %s", strerror(err));
+        closesocket(sockfd);
+        return NULL;
+    }
+
+    {
+        idun_socket_t *sock = lib_calloc(1, sizeof(*sock));
+        sock->sockfd = sockfd;
+        return sock;
+    }
+}
+
+/* ---- Common socket operations ---- */
+
+/*! \brief Close a socket - idun_socket_t version
+
+  Copy of vice_socket_poll from socket.c using idun_socket_t instead.
+
+  \param sockfd
+     The socket to be closed
+
+  \return
+     0 on success, else an error occurred.
+*/
+int idun_socket_close(idun_socket_t *sockfd)
+{
+    int error = -1;
+    if (sockfd) {
+        error = closesocket(sockfd->sockfd);
+        lib_free(sockfd);
+    }
+    return error;
+}
+
+/*! \brief Check socket has incoming data to receive - idun_socket_t version
+
+  Copy of vice_socket_poll from socket.c using idun_socket_t instead.
+
+  \param readsockfd
+     The connected socket to test for data
+
+  \return
+     1 if the specified socket has data; 0 if it does not contain
+     any data, and -1 in case of an error.
+*/
+int idun_socket_poll(idun_socket_t *sockfd)
+{
+    TIMEVAL timeout = { 0, 0 };
+    fd_set fdsockset;
+
+    FD_ZERO(&fdsockset);
+    FD_SET(sockfd->sockfd, &fdsockset);
+
+    return select(sockfd->sockfd + 1, &fdsockset, NULL, NULL, &timeout);
+}
+
+/*! \brief Receive data from a datagram socket
+
+  This function receives incoming data from a datagram socket.
+
+  \param sockfd
+     The connected socket to receive from
+
+  \param buffer
+     Pointer to the buffer which will hold the received data
+
+  \param buffer_length
+     The length of the buffer pointed to by buffer. This
+     indicates the maximum number of bytes to receive.
+
+  \param flags
+     Flags for the socket. These flags are architecture dependent.
+
+  \return
+     the number of bytes received. This can be less than
+     buffer_length.
+
+     In case of an error, -1 is returned.
+*/
+ssize_t idun_socket_recvfrom(idun_socket_t *sockfd, void *buffer, size_t buffer_length, int flags)
+{
+    ssize_t ret;
+
+    signals_pipe_set();
+    ret = recvfrom(sockfd->sockfd, buffer, buffer_length, flags, NULL, NULL);
+    signals_pipe_unset();
+
+    return ret;
+}
+
+#endif /* HAVE_NETWORK */

--- a/vice/src/c64/cart/idunsocket.h
+++ b/vice/src/c64/cart/idunsocket.h
@@ -1,0 +1,41 @@
+/*
+ * idunsocket.h - Idun cartridge socket abstraction for unix domain and UDP.
+ *
+ * Written by
+ *  Brian Holdsworth <brian.holdsworth@gmail.com>
+ *  Deniss Vorona <arimyr@gmail.com>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#ifndef IDUN_SOCKET_H
+#define IDUN_SOCKET_H
+
+#include "types.h"
+
+typedef struct idun_socket_s idun_socket_t;
+
+idun_socket_t *idun_socket_open_unix(const char *path);
+idun_socket_t *idun_socket_open_udp(unsigned short port);
+int idun_socket_close(idun_socket_t *sockfd);
+int idun_socket_poll(idun_socket_t *sockfd);
+ssize_t idun_socket_recvfrom(idun_socket_t *sockfd, void *buffer, size_t buffer_length, int flags);
+
+#endif /* IDUN_SOCKET_H */

--- a/vice/src/socket.c
+++ b/vice/src/socket.c
@@ -753,6 +753,67 @@ static int vice_network_address_generate_ipv6(vice_network_socket_address_t * so
 #endif /* #ifdef HAVE_IPV6 */
 }
 
+#if 0
+/*! \internal \brief Generate a unix domain socket address
+
+  Initialises a socket address with a unix domain socket address
+
+  \param socket_address
+     Pointer to an empty socket address that will be initialized
+
+  \param address_string
+     A string describing the address to set.
+
+  \return
+     0 on success,
+     else an error occurred.
+
+  \remark
+     address_string must be the path of a special file
+     which represents the Unix domain socket.
+
+  \remark
+     On platforms which do not support unix domain sockets, this function
+     returns -1 as error.
+*/
+static int vice_network_address_generate_local(vice_network_socket_address_t * socket_address, const char * address_string)
+{
+#ifdef HAVE_UNIX_DOMAIN_SOCKETS
+    int error = 1;
+
+    do {
+        if (address_string[0] == 0) {
+            break;
+        }
+
+        /* initialise the socket address */
+
+        memset(&socket_address->address, 0, sizeof socket_address->address);
+        socket_address->domain = PF_UNIX;
+        socket_address->protocol = 0;
+        socket_address->len = sizeof socket_address->address.local;
+        socket_address->address.local.sun_family = AF_UNIX;
+
+        if (strlen(address_string) >= sizeof socket_address->address.local.sun_path) {
+            log_message(LOG_DEFAULT,
+                        "Unix domain socket name of '%s' is too long; only %"PRI_SIZE_T" chars are allowed.",
+                        address_string, sizeof(socket_address->address.local.sun_path));
+            break;
+        }
+        strcpy(socket_address->address.local.sun_path, address_string);
+
+        error = 0;
+    } while (0);
+
+    return error;
+
+#else /* #ifdef HAVE_UNIX_DOMAIN_SOCKETS */
+    log_message(LOG_DEFAULT, "Unix domain sockets are not supported in this installation of VICE!\n");
+    return -1;
+#endif /* #ifdef HAVE_UNIX_DOMAIN_SOCKETS */
+}
+#endif
+
 /*! \brief Generate a socket address
 
   Initialises a socket address with the value
@@ -774,7 +835,9 @@ static int vice_network_address_generate_ipv6(vice_network_socket_address_t * so
      NULL in case of an error.
 
   \remark
-     address_string can be prepended with ip6://
+     If address_string starts with a pipe ('|'), then the
+     address_string is treated as a unix domain socket.
+     Otherwise, address_string can be prepended with ip6://
      or ip4://, in which case address_string is treated
      exactly as an IPv6 or IPv4 address, respectively.
 
@@ -792,6 +855,14 @@ vice_network_socket_address_t * vice_network_address_generate(const char * addre
         if (socket_address == NULL) {
             break;
         }
+#if 0 /* FIXME: "|" as first character indicates that we want to pipe through an external process - if we
+                want to support unix domain socket, this has to use another syntax! */
+        if (address_string && address_string[0] == '|') {
+            if (vice_network_address_generate_local(socket_address, &address_string[1])) {
+                break;
+            }
+        } else
+#endif
         if (address_string && strncmp("ip6://", address_string, sizeof "ip6://" - 1) == 0) {
             if (vice_network_address_generate_ipv6(socket_address, &address_string[sizeof "ip6://" - 1], port)) {
                 break;

--- a/vice/src/socket.c
+++ b/vice/src/socket.c
@@ -473,73 +473,6 @@ vice_network_socket_t *vice_network_server(
     return sockfd == INVALID_SOCKET ? NULL : vice_network_alloc_new_socket(sockfd);
 }
 
-/*! \brief Open a socket and initialise it for unix datagram
-     operation
-
-  \param server_address
-     The unix domain socket endpoint to bind to.
-
-  \return
-     0 on error;
-     else, a handle to the socket on success.
-
-  \remark
-     The server_address variable must be for a Unix Domain
-     Socket.
-*/
-vice_network_socket_t *vice_network_unix(
-        const vice_network_socket_address_t * server_address)
-{
-#ifdef HAVE_UNIX_DOMAIN_SOCKETS
-    int sockfd = INVALID_SOCKET;
-    int error = 1;
-    int err;
-
-    assert(server_address != NULL);
-
-    do {
-        if (socket_init() < 0) {
-            log_error(LOG_DEFAULT,
-                "vice_network_server(): socket_init() failed");
-            break;
-        }
-
-        sockfd = (int)socket(server_address->domain, SOCK_DGRAM, server_address->protocol);
-        if (sockfd == INVALID_SOCKET) {
-            err = errno;
-            log_error(LOG_DEFAULT,
-                "vice_network_unix(): socket() returned INVALID_SOCKET: %s",
-                strerror(err));
-            break;
-        }
-
-        // Remove old socket file if it exists
-        archdep_remove(server_address->address.local.sun_path);
-
-        if (bind(sockfd, &server_address->address.generic, server_address->len) < 0) {
-            err = errno;
-            log_error(LOG_DEFAULT,
-                "vice_network_unix(): bind() failed: %s",
-                strerror(err));
-            break;
-        }
-        error = 0;
-    } while (0);
-
-    if (error) {
-        if (sockfd != INVALID_SOCKET) {
-            closesocket(sockfd);
-        }
-        sockfd = INVALID_SOCKET;
-    }
-
-    return sockfd == INVALID_SOCKET ? NULL : vice_network_alloc_new_socket(sockfd);
-#else /* #ifdef HAVE_UNIX_DOMAIN_SOCKETS */
-    log_message(LOG_DEFAULT, "Unix domain sockets are not supported in this installation of VICE!\n");
-    return -1;
-#endif /* #ifdef HAVE_UNIX_DOMAIN_SOCKETS */
-}
-
 /*! \brief Open a socket and initialise it for client operation
 
   \param server_address
@@ -820,65 +753,6 @@ static int vice_network_address_generate_ipv6(vice_network_socket_address_t * so
 #endif /* #ifdef HAVE_IPV6 */
 }
 
-/*! \internal \brief Generate a unix domain socket address
-
-  Initialises a socket address with a unix domain socket address
-
-  \param socket_address
-     Pointer to an empty socket address that will be initialized
-
-  \param address_string
-     A string describing the address to set.
-
-  \return
-     0 on success,
-     else an error occurred.
-
-  \remark
-     address_string must be the path of a special file
-     which represents the Unix domain socket.
-
-  \remark
-     On platforms which do not support unix domain sockets, this function
-     returns -1 as error.
-*/
-static int vice_network_address_generate_local(vice_network_socket_address_t * socket_address, const char * address_string)
-{
-#ifdef HAVE_UNIX_DOMAIN_SOCKETS
-    int error = 1;
-
-    do {
-        if (address_string[0] == 0) {
-            break;
-        }
-
-        /* initialise the socket address */
-
-        memset(&socket_address->address, 0, sizeof socket_address->address);
-        socket_address->domain = PF_UNIX;
-        socket_address->protocol = 0;
-        socket_address->len = sizeof socket_address->address.local;
-        socket_address->address.local.sun_family = AF_UNIX;
-
-        if (strlen(address_string) >= sizeof socket_address->address.local.sun_path) {
-            log_message(LOG_DEFAULT,
-                        "Unix domain socket name of '%s' is too long; only %"PRI_SIZE_T" chars are allowed.",
-                        address_string, sizeof(socket_address->address.local.sun_path));
-            break;
-        }
-        strcpy(socket_address->address.local.sun_path, address_string);
-
-        error = 0;
-    } while (0);
-
-    return error;
-
-#else /* #ifdef HAVE_UNIX_DOMAIN_SOCKETS */
-    log_message(LOG_DEFAULT, "Unix domain sockets are not supported in this installation of VICE!\n");
-    return -1;
-#endif /* #ifdef HAVE_UNIX_DOMAIN_SOCKETS */
-}
-
 /*! \brief Generate a socket address
 
   Initialises a socket address with the value
@@ -900,9 +774,7 @@ static int vice_network_address_generate_local(vice_network_socket_address_t * s
      NULL in case of an error.
 
   \remark
-     If address_string starts with a pipe ('|'), then the
-     address_string is treated as a unix domain socket.
-     Otherwise, address_string can be prepended with ip6://
+     address_string can be prepended with ip6://
      or ip4://, in which case address_string is treated
      exactly as an IPv6 or IPv4 address, respectively.
 
@@ -920,11 +792,7 @@ vice_network_socket_address_t * vice_network_address_generate(const char * addre
         if (socket_address == NULL) {
             break;
         }
-        if (address_string && strncmp("unix:", address_string, sizeof "unix:" - 1) == 0) {
-            if (vice_network_address_generate_local(socket_address, &address_string[sizeof "unix:" - 1])) {
-                break;
-            }
-        } else if (address_string && strncmp("ip6://", address_string, sizeof "ip6://" - 1) == 0) {
+        if (address_string && strncmp("ip6://", address_string, sizeof "ip6://" - 1) == 0) {
             if (vice_network_address_generate_ipv6(socket_address, &address_string[sizeof "ip6://" - 1], port)) {
                 break;
             }
@@ -1111,40 +979,6 @@ ssize_t vice_network_receive(vice_network_socket_t * sockfd, void * buffer, size
 
     signals_pipe_set();
     ret = recv(sockfd->sockfd, buffer, buffer_length, flags);
-    signals_pipe_unset();
-
-    return ret;
-}
-
-/*! \brief Receive data from a datagram socket
-
-  This function receives incoming data from a datagram socket.
-
-  \param sockfd
-     The connected socket to receive from
-
-  \param buffer
-     Pointer to the buffer which will hold the received data
-
-  \param buffer_length
-     The length of the buffer pointed to by buffer. This
-     indicates the maximum number of bytes to receive.
-
-  \param flags
-     Flags for the socket. These flags are architecture dependent.
-
-  \return
-     the number of bytes received. This can be less than
-     buffer_length.
-
-     In case of an error, -1 is returned.
-*/
-ssize_t vice_network_recvfrom(vice_network_socket_t * sockfd, void * buffer, size_t buffer_length, int flags)
-{
-    ssize_t ret;
-
-    signals_pipe_set();
-    ret = recvfrom(sockfd->sockfd, buffer, buffer_length, flags, NULL, NULL);
     signals_pipe_unset();
 
     return ret;

--- a/vice/src/vicesocket.h
+++ b/vice/src/vicesocket.h
@@ -37,7 +37,6 @@ typedef struct vice_network_socket_s vice_network_socket_t;
 typedef struct vice_network_socket_address_s vice_network_socket_address_t;
 
 vice_network_socket_t * vice_network_server(const vice_network_socket_address_t * server_address);
-vice_network_socket_t *vice_network_unix(const vice_network_socket_address_t * server_address);
 vice_network_socket_t * vice_network_client(const vice_network_socket_address_t * server_address);
 
 vice_network_socket_address_t * vice_network_address_generate(const char * address, unsigned short port);
@@ -49,7 +48,6 @@ int vice_network_socket_close(vice_network_socket_t * sockfd);
 
 ssize_t vice_network_send(vice_network_socket_t * sockfd, const void * buffer, size_t buffer_length, int flags);
 ssize_t vice_network_receive(vice_network_socket_t * sockfd, void * buffer, size_t buffer_length, int flags);
-ssize_t vice_network_recvfrom(vice_network_socket_t * sockfd, void * buffer, size_t buffer_length, int flags);
 
 int vice_network_select_poll_one(vice_network_socket_t * readsockfd);
 int vice_network_select_multiple(vice_network_socket_t ** readsockfd);


### PR DESCRIPTION
- idun socket functions moved to idunsocket.c
- socket.c is now vanilla from 3.9 vice
- UDP socket for NMI datagrams added
- Unix domain socket is initialized when iduncart is configured to be accessed as localhost or 127.0.0.1
- UDP is initialized otherwise