### PR TITLE
Windows batch files, README update and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## Vice Emulator for Idun Cartridge
+# Vice Emulator for Idun Cartridge
 
 Developing for the idun cart can be done using Vice. This patched version of Vice connects to the Raspberry Pi on your Idun cartridge and lets you run an emulated environment either directly on the Raspberry Pi, or from a remote PC. Most of the features of the idun cart are available through the emulator, including developing apps that use Lua. What does not work is the `go64` and `load` commands from the idun shell.
 
 This emulator can also work for development even if you lack the actual idun cartidge hardware. You can download the image for idun, burn it to an SD card, and use it to boot most versions of Raspberry Pi. You need a RPi with ARMv7, at least 512MB of RAM, and a 4GB SD card.
 
-### Installation
+## Installation
 
 To use the emulator on the Raspberry Pi connected with your idun cart, install the latest release from the idun package repository. If you are new to `pacman`, consider perusing the Arch Linux [pacman primer](https://wiki.archlinux.org/title/Pacman).
 
@@ -16,7 +16,7 @@ Connect a keyboard to your RPi, and start the emulator using the included launch
 
 _Note_: `idun-vice/emu64.sh` is sort of ancillary. It exists mainly because the `go64` shell command doesn't work in the emulator. Instead, you can exit the x128 emulator (`emu.sh`), and start the x64sc emulator (`emu64.sh`), without upsetting the state of the cartridge.
 
-### Building
+## Building
 
 This GitHub repo is fully buildable on a RPi.
 ```
@@ -27,7 +27,7 @@ cd idun-vice
 
 If you want to build modified Vice binaries for other platforms, then start in directory `idun-vice/vice` and build things the normal way using `configure` and `make`, or follow the details for your platform in the Vice documentation.
 
-### Using without idun-cartridge
+## Using without idun-cartridge
 
 - You will need to edit `~/.config/idunrc.toml` and comment out the setting for `io.serial` such as shown below. This will stop the RPi continually trying to re-connect with the cartridge, otherwise it's unusable!
 ```
@@ -37,8 +37,14 @@ If you want to build modified Vice binaries for other platforms, then start in d
 - You will also need to make an addition to `/etc/systemd/system/idun.service`. In the section under `[Service]`, add an additional line
     + `Environment=IDUN_MODE_SWITCH=False`
     + This variable is used to toggle whether the Mode switch is seen as enabled when you don't have an actual idun-cart connected to the RPi.
+
+## Remote Vice
+
 - To connect to the RPi from a PC running the emulator, make sure `io.devsock` is set as shown below. Otherwise, only local connection is allowed!
 ```
 [io]
 devsock = "0.0.0.0:25232"	# allow remote emulator connection
 ```
+- IDUN software on RPi will send UDP datagrams back to Vice on port 64128 using IP address determined from incoming connection.
+- On Windows `emu.bat` will start C128 connected to IDUN on RPi and `emu64.bat` will start C64 connected to IDUN on RPi.
+- RPi address can be supplied as parameter to those, or it can be specified using IDUNHOST environment variable

--- a/vice/idun/emu.bat
+++ b/vice/idun/emu.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal
+
+:: Manually specify fallback host (leave empty to require command-line or IDUNHOST env var)
+set FALLBACK_HOST=
+set PORT=25232
+
+:: Resolve host: command-line arg > IDUNHOST env var > fallback
+if not "%~1"=="" (
+    set HOST=%~1
+) else if not "%IDUNHOST%"=="" (
+    set HOST=%IDUNHOST%
+) else if not "%FALLBACK_HOST%"=="" (
+    set HOST=%FALLBACK_HOST%
+) else (
+    echo ERROR: No host specified. Pass IP as argument, set IDUNHOST env var, or set FALLBACK_HOST in this script.
+    exit /b 1
+)
+
+:: Find latest GTK3VICE-*-win64 in current dir, then one level up
+set VICEDIR=
+for /d %%D in (GTK3VICE-*-win64) do set VICEDIR=%%D
+if "%VICEDIR%"=="" (
+    for /d %%D in (..\GTK3VICE-*-win64) do set VICEDIR=%%D
+)
+if "%VICEDIR%"=="" (
+    echo ERROR: Could not find GTK3VICE-*-win64 directory in current or parent directory.
+    exit /b 1
+)
+
+echo Starting %VICEDIR% connecting to %HOST%:%PORT% ...
+"%VICEDIR%\bin\x128" -pal -80col -idunhost %HOST%:%PORT% -idunio -cartidun128 resc/emu.rom -c128fullbanks

--- a/vice/idun/emu64.bat
+++ b/vice/idun/emu64.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal
+
+:: Manually specify fallback host (leave empty to require command-line or IDUNHOST env var)
+set FALLBACK_HOST=
+set PORT=25232
+
+:: Resolve host: command-line arg > IDUNHOST env var > fallback
+if not "%~1"=="" (
+    set HOST=%~1
+) else if not "%IDUNHOST%"=="" (
+    set HOST=%IDUNHOST%
+) else if not "%FALLBACK_HOST%"=="" (
+    set HOST=%FALLBACK_HOST%
+) else (
+    echo ERROR: No host specified. Pass IP as argument, set IDUNHOST env var, or set FALLBACK_HOST in this script.
+    exit /b 1
+)
+
+:: Find latest GTK3VICE-*-win64 in current dir, then one level up
+set VICEDIR=
+for /d %%D in (GTK3VICE-*-win64) do set VICEDIR=%%D
+if "%VICEDIR%"=="" (
+    for /d %%D in (..\GTK3VICE-*-win64) do set VICEDIR=%%D
+)
+if "%VICEDIR%"=="" (
+    echo ERROR: Could not find GTK3VICE-*-win64 directory in current or parent directory.
+    exit /b 1
+)
+
+echo Starting %VICEDIR% connecting to %HOST%:%PORT% ...
+"%VICEDIR%\bin\x64sc" -pal -idunhost %HOST%:%PORT% -idunio -cartidun resc/emu64.rom

--- a/vice/idun/package-win64.bat
+++ b/vice/idun/package-win64.bat
@@ -1,0 +1,48 @@
+@echo off
+setlocal
+
+:: Require version suffix as command-line argument
+if "%~1"=="" (
+    echo Usage: package-win64.bat ^<suffix^>
+    echo   e.g. package-win64.bat 1.2.3-1
+    exit /b 1
+)
+set SUFFIX=%~1
+
+:: Find latest GTK3VICE-*-win64 in parent directory
+set VICENAME=
+for /d %%D in (..\GTK3VICE-*-win64) do set VICENAME=%%~nxD
+if "%VICENAME%"=="" (
+    echo ERROR: Could not find GTK3VICE-*-win64 directory in parent directory.
+    exit /b 1
+)
+
+:: Extract upstream version number from directory name (GTK3VICE-X.Y-win64 -> X.Y)
+set UPSTREAM=%VICENAME:GTK3VICE-=%
+set UPSTREAM=%UPSTREAM:-win64=%
+
+:: Build zip name: GTK3VICE-(upstream)-idun-(suffix)-win64
+set PKGNAME=GTK3VICE-%UPSTREAM%-idun-%SUFFIX%-win64
+set ZIPFILE=%CD%\%PKGNAME%.zip
+set STAGEDIR=%TEMP%\idun-pkg-%RANDOM%\%PKGNAME%
+
+echo Staging into %STAGEDIR% ...
+mkdir "%STAGEDIR%"
+
+:: Copy bat files, README and resc to top level inside subdir
+copy emu*.bat "%STAGEDIR%\" > nul
+copy ..\..\README.md "%STAGEDIR%\" > nul
+xcopy /e /i /q resc "%STAGEDIR%\resc\" > nul
+
+:: Copy GTK3VICE directory preserving its name inside subdir
+xcopy /e /i /q "..\%VICENAME%" "%STAGEDIR%\%VICENAME%\" > nul
+
+:: Create zip
+if exist "%ZIPFILE%" del "%ZIPFILE%"
+echo Packing %ZIPFILE% ...
+powershell -NoProfile -Command "Compress-Archive -Path \"%STAGEDIR%\" -DestinationPath \"%ZIPFILE%\""
+
+:: Cleanup
+rmdir /s /q "%STAGEDIR%\.."
+
+echo Done: %ZIPFILE%


### PR DESCRIPTION
- Added some instruction on windows version and remote usage into README.md
- emu.bat and emu64.bat files that can run inside cleaned up packaging (where vice itself is in subdirectory) and in compiled directory (where vice is in subdirectory of parent dir)